### PR TITLE
updating package.swift dependencies 

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -54,11 +54,11 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "1.0.1")),
     ]
-    
+
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.
     #if swift(>=5.6)
     package.dependencies += [
-        .package(url: "https://github.com/bitjammer/swift-docc-plugin", .branch("acgarland/snippets")),
+        .package(url: "https://github.com/apple/swift-docc-plugin", .branch("main")),
     ]
     #endif
 } else {

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -58,7 +58,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     // SwiftPM command plugins are only supported by Swift version 5.6 and later.
     #if swift(>=5.6)
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/bitjammer/swift-docc-plugin", .branch("acgarland/snippets")),
     ]
     #endif
 } else {

--- a/Snippets/Formatting/DefaultFormatting.swift
+++ b/Snippets/Formatting/DefaultFormatting.swift
@@ -1,0 +1,28 @@
+//! Format a parsed Markdown document with default settings.
+
+import Markdown
+
+let source = """
+|a|b|c|
+|-|-|-|
+|*Some text*||<https://swift.org>|
+"""
+
+let document = Document(parsing: source)
+let formattedSource = document.format()
+
+// MARK: Hide
+
+print("""
+## Original source:
+```
+\(source)
+```
+""")
+
+print("""
+## Formatted source:
+```
+\(formattedSource)
+```
+""")

--- a/Snippets/Formatting/MaximumWidth.swift
+++ b/Snippets/Formatting/MaximumWidth.swift
@@ -1,0 +1,25 @@
+//! Keep lines under a certain length.
+import Markdown
+
+let source = """
+This is a really, really, really, really, really, really, really, really, really, really, really long line.
+"""
+
+let document = Document(parsing: source)
+let lineLimit = MarkupFormatter.Options.PreferredLineLimit(maxLength: 80, breakWith: .softBreak)
+let formattingOptions = MarkupFormatter.Options(preferredLineLimit: lineLimit)
+let newSource = document.format(options: formattingOptions)
+
+// MARK: Hide
+
+print("## Original source:")
+print("```")
+print(source)
+print("```")
+print()
+
+print("## Formatted source:")
+print("```")
+print(newSource)
+print("```")
+print()

--- a/Snippets/Parsing/ParseDocumentFile.swift
+++ b/Snippets/Parsing/ParseDocumentFile.swift
@@ -1,0 +1,14 @@
+//! Parse the contents of a file by its ``URL`` without having to read
+//! its contents yourself.
+
+import Foundation
+import Markdown
+
+let file = URL(fileURLWithPath: "test.md")
+let document = try Document(parsing: file)
+
+// MARK: HIDE
+
+print("Parsed \(file.path)")
+print("## Parsed document structure")
+print(document.debugDescription())

--- a/Snippets/Parsing/ParseDocumentString.swift
+++ b/Snippets/Parsing/ParseDocumentString.swift
@@ -1,0 +1,12 @@
+//! Parse a ``String`` as Markdown
+
+import Markdown
+
+let source = "Some *Markdown* source"
+let document = Document(parsing: source)
+
+// MARK: HIDE
+
+print("Parsed \(source.debugDescription)")
+print("## Parsed document structure")
+print(document.debugDescription())

--- a/Snippets/Parsing/test.md
+++ b/Snippets/Parsing/test.md
@@ -1,0 +1,3 @@
+# Sample document
+
+This is a *sample document*.

--- a/Snippets/Rewriters/RemoveElementKind.swift
+++ b/Snippets/Rewriters/RemoveElementKind.swift
@@ -1,0 +1,41 @@
+//! Remove all instances of a kind of element using a `MarkupRewriter`.
+import Markdown
+
+// MARK: Hide
+
+let source = """
+The strong emphasis element is **going to be** deleted.
+"""
+
+// MARK: Show
+
+struct StrongDeleter: MarkupRewriter {
+  func visitStrong(_ strong: Strong) -> Markup? {
+    return nil
+  }
+}
+
+let document = Document(parsing: source)
+var deleter = StrongDeleter()
+let newDocument = deleter.visit(document) as! Document
+
+// MARK: Hide
+
+print("## Original source:")
+print("```")
+print(source)
+print("```")
+print()
+
+print("## Original Markdown tree:")
+print(document.debugDescription())
+print()
+
+print("## New Markdown tree:")
+print(newDocument.debugDescription())
+print()
+
+print("## New source:")
+print("```")
+print(newDocument.format())
+print("```")

--- a/Sources/Markdown/Markdown.docc/Markdown.md
+++ b/Sources/Markdown/Markdown.docc/Markdown.md
@@ -10,6 +10,10 @@ The markup tree provided by this package is comprised of immutable/persistent, t
 
 ## Topics
 
+### Snippets
+
+- <doc:snippets>
+
 ### Getting Started
 
 - <doc:Parsing-Building-and-Modifying-Markup-Trees>

--- a/Sources/Markdown/Markdown.docc/snippets.md
+++ b/Sources/Markdown/Markdown.docc/snippets.md
@@ -1,0 +1,15 @@
+# Snippets
+
+## Parsing
+
+@Snippet(path: "swift-markdown/snippets/ParseDocumentString")
+@Snippet(path: "swift-markdown/snippets/ParseDocumentFile")
+
+## Formatting
+
+@Snippet(path: "swift-markdown/snippets/DefaultFormatting"
+@Snippet(path: "swift-markdown/snippets/MaximumWidth")
+
+## Rewriters
+
+@Snippet(path: "swift-markdown/snippets/RemoveElementKind")


### PR DESCRIPTION
## Summary

Since the `acgarland/snippets` branch on `swift-docc-plugin` was merged into the main branch for that repo, this example setup needed a touch of tweaking to get it to work per the [forum instructions](https://forums.swift.org/t/pitch-swift-snippets/56348). This just tweaks things a smidge - you may not even want it, but for anyone else trying out snippets per your instructions in the forum, they'll need this tweak.
