### PR TITLE
Updated snippets to use latest implementation

### DIFF
--- a/Snippets/Formatting/DefaultFormatting.swift
+++ b/Snippets/Formatting/DefaultFormatting.swift
@@ -1,4 +1,4 @@
-//! Format a parsed Markdown document with default settings.
+// Format a parsed Markdown document with default settings.
 
 import Markdown
 

--- a/Snippets/Formatting/MaximumWidth.swift
+++ b/Snippets/Formatting/MaximumWidth.swift
@@ -1,4 +1,4 @@
-//! Keep lines under a certain length.
+// Keep lines under a certain length.
 import Markdown
 
 let source = """

--- a/Snippets/Parsing/ParseDocumentFile.swift
+++ b/Snippets/Parsing/ParseDocumentFile.swift
@@ -1,5 +1,4 @@
-//! Parse the contents of a file by its ``URL`` without having to read
-//! its contents yourself.
+// Parse the contents of a file by its ``URL`` without having to read its contents yourself.
 
 import Foundation
 import Markdown

--- a/Snippets/Parsing/ParseDocumentString.swift
+++ b/Snippets/Parsing/ParseDocumentString.swift
@@ -1,4 +1,4 @@
-//! Parse a ``String`` as Markdown
+// Parse a ``String`` as Markdown
 
 import Markdown
 

--- a/Snippets/Rewriters/RemoveElementKind.swift
+++ b/Snippets/Rewriters/RemoveElementKind.swift
@@ -1,4 +1,4 @@
-//! Remove all instances of a kind of element using a `MarkupRewriter`.
+// Remove all instances of a kind of element using a `MarkupRewriter`.
 import Markdown
 
 // MARK: Hide

--- a/Sources/Markdown/Markdown.docc/snippets.md
+++ b/Sources/Markdown/Markdown.docc/snippets.md
@@ -2,14 +2,14 @@
 
 ## Parsing
 
-@Snippet(path: "swift-markdown/snippets/ParseDocumentString")
-@Snippet(path: "swift-markdown/snippets/ParseDocumentFile")
+@Snippet(path: "swift-markdown/Snippets/Parsing/ParseDocumentString")
+@Snippet(path: "swift-markdown/Snippets/Parsing/ParseDocumentFile")
 
 ## Formatting
 
-@Snippet(path: "swift-markdown/snippets/DefaultFormatting"
-@Snippet(path: "swift-markdown/snippets/MaximumWidth")
+@Snippet(path: "swift-markdown/Snippets/Formatting/DefaultFormatting"
+@Snippet(path: "swift-markdown/Snippets/Formatting/MaximumWidth")
 
 ## Rewriters
 
-@Snippet(path: "swift-markdown/snippets/RemoveElementKind")
+@Snippet(path: "swift-markdown/Snippets/Rewriters/RemoveElementKind")


### PR DESCRIPTION
Changed the @Snippet URLs to use the full path to the correct snippets, and changed the //! comment format to just regular // comments to lead each snippets.